### PR TITLE
Revert "Switch nginx-unit to Gunicorn"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN \
 ARG NETBOX_PATH
 COPY ${NETBOX_PATH}/requirements.txt requirements-container.txt /
 RUN \
+    # Gunicorn is not needed because we use Nginx Unit
+    sed -i -e '/gunicorn/d' /requirements.txt && \
     # We need 'social-auth-core[all]' in the Docker image. But if we put it in our own requirements-container.txt
     # we have potential version conflicts and the build will fail.
     # That's why we just replace it in the original requirements.txt.
@@ -47,7 +49,9 @@ RUN \
       libxmlsec1-openssl1 \
       openssh-clients \
       catatonit \
-      system-user-wwwrun \
+    && zypper -n ar -G -f -p 100 https://packages.nginx.org/unit/fedora/38/x86_64/ nginx-unit \
+    && zypper -n in \
+      unit-python311 \
     && zypper -n cc -a && rm -r /var/{cache,log}/*
 
 COPY --from=builder /opt/netbox/venv /opt/netbox/venv
@@ -65,8 +69,6 @@ COPY docker/launch-netbox.sh /opt/netbox/launch-netbox.sh
 COPY configuration/ /etc/netbox/config/
 COPY docker/nginx-unit.json /etc/unit/
 
-COPY docker/launch-netbox-gunicorn.sh /opt/netbox/
-
 # Plugins and plugin configuration
 COPY ./plugin_requirements.txt /opt/netbox/
 COPY configuration/configuration.py /etc/netbox/config/configuration.py
@@ -78,14 +80,12 @@ COPY ./local_settings.py /opt/netbox/netbox/netbox/
 # Install plugins
 RUN /opt/netbox/venv/bin/pip install  --no-warn-script-location -r /opt/netbox/plugin_requirements.txt
 
-RUN printf 'MIDDLEWARE = MIDDLEWARE + ["whitenoise.middleware.WhiteNoiseMiddleware"]\nSTATIC_ROOT = "/opt/netbox/netbox/static"\nSTATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"' >> /opt/netbox/netbox/netbox/settings.py
-
 WORKDIR /opt/netbox/netbox
 
 # Must set permissions for '/opt/netbox/netbox/media' directory
 # to g+w so that pictures can be uploaded to netbox.
 RUN mkdir -p static /opt/unit/state/ /opt/unit/tmp/ \
-      && chown -R wwwrun:root /opt/unit/ media reports scripts \
+      && chown -R unit:root /opt/unit/ media reports scripts \
       && chmod -R g+w /opt/unit/ media reports scripts \
       && cd /opt/netbox/ && SECRET_KEY="dummyKeyWithMinimumLength-------------------------" /opt/netbox/venv/bin/python -m mkdocs build \
           --config-file /opt/netbox/mkdocs.yml --site-dir /opt/netbox/netbox/project-static/docs/ \

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,7 +26,6 @@ services:
     pull_policy: never
     ports:
       - 8000:8080
-    user: wwwrun:www
     labels:
       traefik.enable: "true"
       traefik.http.routers.frontend.rule: "Host(`${NETBOX_HOSTNAME}`)"
@@ -42,11 +41,9 @@ services:
       traefik.http.services.frontend.loadbalancer.passhostheader: true
   netbox-worker:
     image: netbox:${TAG}
-    user: wwwrun:www
     pull_policy: never
   netbox-housekeeping:
     image: netbox:${TAG}
-    user: wwwrun:www
     pull_policy: never
   traefik:
     image: traefik:v2.8

--- a/docker/launch-netbox-gunicorn.sh
+++ b/docker/launch-netbox-gunicorn.sh
@@ -1,9 +1,0 @@
-#!/bin/sh -efu
-
-exec \
-	/opt/netbox/venv/bin/gunicorn \
-	--bind 0.0.0.0:8080 \
-	--config /opt/netbox/netbox-git/contrib/gunicorn.py \
-	--pythonpath /opt/netbox/netbox \
-	--workers $(( $(nproc) + 1 )) \
-	netbox.wsgi

--- a/docker/launch-netbox.sh
+++ b/docker/launch-netbox.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-/opt/netbox/launch-netbox-gunicorn.sh
-exit 1
 
 UNIT_CONFIG="${UNIT_CONFIG-/etc/unit/nginx-unit.json}"
 # Also used in "nginx-unit.json"


### PR DESCRIPTION
This reverts commit 789c4de1f49849e09e5b49541736317f64baabc2. Gunicorn would require another component to serve static files, introducing WhiteNoise was attempted but did not succeed and further investigation is currently not possible.
Hence switch back to the subpar but working Nginx Unit from upstream.