### PR TITLE
Revert "fixup: Do healtcheck on the rest api instead of the login form"

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -51,12 +51,6 @@ services:
       - ./branding/SUSE_NetBox_Pos.svg:/opt/netbox/netbox/static/logo_netbox_dark_teal.svg:ro
       - ./templates/login.html:/opt/netbox/netbox/templates/login.html
     restart: unless-stopped
-    healthcheck:
-      test:
-        - CMD
-        - curl
-        - "-f"
-        - http://127.0.0.1:8080/api/status/?format=json
   netbox-worker:
     env_file: /etc/opt/netbox-docker/netbox.env
     image: netbox:${TAG}


### PR DESCRIPTION
This reverts commit dc52db769a66ddfd6787aa6eb4729e24e8d80882. Health check will fail if mandatory login (the default) is enabled due to /api/status returning 403 and / returning the expected 302 to /login.