### PR TITLE
Raise max_body_size

### DIFF
--- a/docker/nginx-unit.json
+++ b/docker/nginx-unit.json
@@ -73,5 +73,10 @@
       }
     }
   },
-  "access_log": "/dev/stdout"
+  "access_log": "/dev/stdout",
+  "settings": {
+    "http": {
+      "max_body_size": 33554432
+    }
+  }
 }


### PR DESCRIPTION
The default of 8MB was found to be not sufficient for some PDF attachments, graciously allow up to 32MB instead.