### PR TITLE
Switch documents plugin to fork

### DIFF
--- a/plugin_requirements.txt
+++ b/plugin_requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/netbox-community/netbox-healthcheck-plugin
-git+https://github.com/jasonyates/netbox-documents@v0.7.1
+git+https://github.com/tacerus/netbox-documents@suse-main


### PR DESCRIPTION
For compatibility with NetBox 4.3.0, to revert after
jasonyates/netbox-documents#75.