### PR TITLE
Switch documents plugin back to upstream and bump

### DIFF
--- a/plugin_requirements.txt
+++ b/plugin_requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/netbox-community/netbox-healthcheck-plugin
-git+https://github.com/tacerus/netbox-documents@suse-main
+git+https://github.com/jasonyates/netbox-documents@v0.7.3


### PR DESCRIPTION
This reverts commit f9cfcbd5033ec0b32c2ce3013d04d822bc872d42 and bumps the tag now that the needed patch was merged upstream.