### PR TITLE
Adjust login button to SUSEID

### DIFF
--- a/configuration/extra.py
+++ b/configuration/extra.py
@@ -175,3 +175,7 @@ FIELD_CHOICES = {
         ('warranty', 'Warranty information or RMA', 'red'),
     ),
 }
+
+SOCIAL_AUTH_BACKEND_ATTRS = {
+    'oidc': ('Log in with SUSEID', 'login'),
+}

--- a/templates/login.html
+++ b/templates/login.html
@@ -33,11 +33,7 @@
                   <a href="{{ backend.url }}" class="btn w-100">
                     {% if backend.icon_name %}<i class="mdi mdi-{{ backend.icon_name }}"></i>
                     {% elif backend.icon_img %}<img src="{{ backend.icon_img }}" height="24"{% if backend.display_name %}class="me-2 sso-icon" {% endif %}/>{% endif %}
-                    {% if backend.display_name == 'opensuse' %}
-                    Log in with openSUSE IDP
-                    {% else %}
                     {{ backend.display_name }}
-                    {% endif %}
                   </a>
                 </div>
               {% endfor %}


### PR DESCRIPTION
After the authentication backend is switched, display a matching human instead of the technical name again. Refactor to the more idiomatic configuration based approach whilst at it, which includes a little icon too.


<img width="675" height="516" alt="image" src="https://github.com/user-attachments/assets/b0d12db2-62f0-41d4-bf8f-5adeafa04597" />
