### PR TITLE
Remove local_settings.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,9 +79,6 @@ COPY ./plugin_requirements.txt /opt/netbox/
 COPY configuration/configuration.py /etc/netbox/config/configuration.py
 COPY configuration/plugins.py /etc/netbox/config/plugins.py
 
-# Plugin configuration only possible via settings.py
-COPY ./local_settings.py /opt/netbox/netbox/netbox/
-
 # Install plugins
 RUN /opt/netbox/venv/bin/pip install  --no-warn-script-location -r /opt/netbox/plugin_requirements.txt
 

--- a/local_settings.py
+++ b/local_settings.py
@@ -1,4 +1,0 @@
-from os import environ
-from urllib.parse import quote
-
-REDIS_URL = f"redis://:{quote(environ.get('REDIS_PASSWORD', ''))}@{environ.get('REDIS_HOST', 'localhost')}:{environ.get('REDIS_PORT', '6379')}/{environ.get('REDIS_DATABASE', '1')}"


### PR DESCRIPTION
The additional configuration is no longer needed. We only used it for REDIS_URL, and the healthcheck plugin which consumed this setting was now updated to read the needed information from the stock configuration.