### PR TITLE
Switch healthcheck plugin to fork

### DIFF
--- a/plugin_requirements.txt
+++ b/plugin_requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/netbox-community/netbox-healthcheck-plugin
+git+https://github.com/tacerus/netbox-healthcheck-plugin@suse-main
 git+https://github.com/jasonyates/netbox-documents@v0.7.3


### PR DESCRIPTION
To restore compatibility with all Redis passwords, to revert after https://github.com/netbox-community/netbox-healthcheck-plugin/pull/20.