### PR TITLE
Switch plugins to SUSE forks

### DIFF
--- a/plugin_requirements.txt
+++ b/plugin_requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/tacerus/netbox-healthcheck-plugin@suse-main
-git+https://github.com/tacerus/netbox-documents@suse-main
+git+https://github.com/SUSE/netbox-healthcheck-plugin@suse-main
+git+https://github.com/SUSE/netbox-documents@suse-main


### PR DESCRIPTION
My temporary forks turned out not so temporary, hence move them to a more official place.